### PR TITLE
Update the django path to flatatt module

### DIFF
--- a/taggit_bootstrap/widgets.py
+++ b/taggit_bootstrap/widgets.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
-from django.forms.util import flatatt
+from django.forms.utils import flatatt
 from django.utils.encoding import force_text
 
 from taggit.utils import parse_tags, edit_string_for_tags


### PR DESCRIPTION
I updated the path the flatatt module in the latest Django version (1.9). The pass has changed since version 1.7.